### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -1,4 +1,6 @@
 name: Basic Tests
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/KEINOS/go-relver/security/code-scanning/4](https://github.com/KEINOS/go-relver/security/code-scanning/4)

To remediate this issue, add a `permissions` block to the workflow or to individual jobs to restrict the GITHUB_TOKEN to the least privileges required. Since these jobs only check out code and run tests, they require at most `contents: read` permission to access the repository. The change should be made at the root of the workflow (top-level, after the `name` and before `on`), which will apply these settings to all jobs unless a job-specific `permissions` block is present. No other changes, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
