### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/KEINOS/go-relver/security/code-scanning/1](https://github.com/KEINOS/go-relver/security/code-scanning/1)

The solution is to explicitly add a `permissions` block to the workflow. Since only read access to repository contents is needed for actions like checkout and running tests, set `contents: read` as the minimal privilege at the workflow-level (lines before `jobs:`). This covers all jobs (there’s only one here) and applies least privilege. No changes to the job structure or any step logic are needed. Edit `.github/workflows/code-coverage.yml` to insert:

```yaml
permissions:
  contents: read
```

below the `name` and `on` blocks (best practice is after `on:` and before `jobs:`). No imports, new methods, or other structural changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
